### PR TITLE
feat: support audience as vector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 coarsetime = "0.1"
 ct-codecs = "0.1"
 ed25519-compact = "0.1"
+either = {version = "1.6", features = ["serde"] }
 hmac-sha256 = { version = "0.1", features = ["traits"] }
 hmac-sha512 = { version = "0.1", features = ["traits", "sha384"] }
 k256 = { version = "0.5", features = ["ecdsa", "std"] }


### PR DESCRIPTION
As stated in https://tools.ietf.org/html/rfc7519#section-4.1.3, the audience is an array of strings or uris. This code allows to define it as a string or an array, as many tools or services use them in both format. Serialization is either a string or a json array.

This implementation is based on [either](https://github.com/bluss/either). 

:warning: Please note that the API compatibility is broken as `audience` is now an `Option<Either<String, Vec<String>>>` instead of an `Option<String>`.

In addition, I will add audience verification in this PR.