### PR TITLE
increase jwt header limit

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -6,7 +6,7 @@ use crate::common::*;
 use crate::error::*;
 use crate::jwt_header::*;
 
-pub const MAX_HEADER_LENGTH: usize = 4096;
+pub const MAX_HEADER_LENGTH: usize = 8192;
 
 /// Utilities to get information about a JWT token
 pub struct Token;


### PR DESCRIPTION
Hi Frank, believe it or not I ran into a real world use case where a JWT header > 4kb [1]. I read that the spec says the entire JWT should be under 8kb to fit into a HTTP header, but I'm not sure if it's a hard limit.

[1]: https://developer.android.com/training/safetynet/attestation