### PR TITLE
Implement Clone for RSA, HMAC and EdDSA key types

### DIFF
--- a/src/algorithms/eddsa.rs
+++ b/src/algorithms/eddsa.rs
@@ -8,7 +8,7 @@ use crate::jwt_header::*;
 use crate::token::*;
 
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Edwards25519PublicKey(ed25519_compact::PublicKey);
 
 impl AsRef<ed25519_compact::PublicKey> for Edwards25519PublicKey {
@@ -31,6 +31,7 @@ impl Edwards25519PublicKey {
 }
 
 #[doc(hidden)]
+#[derive(Clone)]
 pub struct Edwards25519KeyPair(ed25519_compact::KeyPair);
 
 impl AsRef<ed25519_compact::KeyPair> for Edwards25519KeyPair {
@@ -119,6 +120,7 @@ pub trait EdDSAPublicKeyLike {
     }
 }
 
+#[derive(Clone)]
 pub struct Ed25519KeyPair {
     key_pair: Edwards25519KeyPair,
     key_id: Option<String>,

--- a/src/algorithms/hmac.rs
+++ b/src/algorithms/hmac.rs
@@ -11,7 +11,7 @@ use crate::jwt_header::*;
 use crate::token::*;
 
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HMACKey(Vec<u8>);
 
 impl Drop for HMACKey {
@@ -92,7 +92,7 @@ pub trait MACLike {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HS256Key {
     key: HMACKey,
     key_id: Option<String>,

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -10,7 +10,7 @@ use crate::jwt_header::*;
 use crate::token::*;
 
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RSAPublicKey(rsa::RSAPublicKey);
 
 impl AsRef<rsa::RSAPublicKey> for RSAPublicKey {
@@ -40,7 +40,7 @@ impl RSAPublicKey {
 }
 
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RSAKeyPair(rsa::RSAPrivateKey);
 
 impl AsRef<rsa::RSAPrivateKey> for RSAKeyPair {
@@ -138,6 +138,7 @@ pub trait RSAPublicKeyLike {
     }
 }
 
+#[derive(Clone)]
 pub struct RS256KeyPair {
     key_pair: RSAKeyPair,
     key_id: Option<String>,


### PR DESCRIPTION
I wanted to use these as part of data passed to handlers in an `actix-web` application which seems to require that they implement `Clone`. The underlying libraries already do, so it's not a big change.

Also, I noticed that the current version number in Cargo.toml is `0.2.4` but the current release is `0.2.5`. Is there some release code missing from the repo?