### PR TITLE
validating iss and aud against multiple values

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ options.time_tolerance = Some(Duration::from_mins(15));
 // reject tokens if they were issued more than 1 hour ago
 options.max_validity = Some(Duration::from_hours(1));
 // reject tokens if they don't come from a specific issuer
-options.required_issuer = Some("example app".to_string());
+options.required_issuers = Some(["example app".to_string()].iter().cloned().collect());
 // see the documentation for the full list of available options
 
 let claims = key.verify_token::<NoCustomClaims>(&token, Some(options))?;

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ options.time_tolerance = Some(Duration::from_mins(15));
 // reject tokens if they were issued more than 1 hour ago
 options.max_validity = Some(Duration::from_hours(1));
 // reject tokens if they don't come from a specific issuer
-options.required_issuers = Some(["example app".to_string()].iter().cloned().collect());
+options.allowed_issuers = Some(["example app".to_string()].iter().cloned().collect());
 // see the documentation for the full list of available options
 
 let claims = key.verify_token::<NoCustomClaims>(&token, Some(options))?;

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -185,10 +185,10 @@ impl<CustomClaims> JWTClaims<CustomClaims> {
                 JWTError::TokenHasExpired
             );
         }
-        if let Some(required_issuers) = &options.required_issuers {
+        if let Some(allowed_issuers) = &options.allowed_issuers {
             if let Some(issuer) = &self.issuer {
                 ensure!(
-                    required_issuers.contains(issuer),
+                    allowed_issuers.contains(issuer),
                     JWTError::RequiredIssuerMismatch
                 );
             } else {
@@ -212,15 +212,15 @@ impl<CustomClaims> JWTClaims<CustomClaims> {
                 bail!(JWTError::RequiredNonceMissing);
             }
         }
-        if let Some(required_audiences) = &options.required_audiences {
+        if let Some(allowed_audiences) = &options.allowed_audiences {
             if let Some(audiences) = &self.audiences {
                 match audiences {
                     Audiences::AsString(audience) => ensure!(
-                        required_audiences.contains(audience),
+                        allowed_audiences.contains(audience),
                         JWTError::RequiredAudienceMismatch
                     ),
                     Audiences::AsSet(audiences) => ensure!(
-                        audiences.intersection(required_audiences).next().is_some(),
+                        audiences.intersection(allowed_audiences).next().is_some(),
                         JWTError::RequiredAudienceMismatch
                     ),
                 };

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -185,9 +185,12 @@ impl<CustomClaims> JWTClaims<CustomClaims> {
                 JWTError::TokenHasExpired
             );
         }
-        if let Some(required_issuer) = &options.required_issuer {
+        if let Some(required_issuers) = &options.required_issuers {
             if let Some(issuer) = &self.issuer {
-                ensure!(issuer == required_issuer, JWTError::RequiredIssuerMismatch);
+                ensure!(
+                    required_issuers.contains(issuer),
+                    JWTError::RequiredIssuerMismatch
+                );
             } else {
                 bail!(JWTError::RequiredIssuerMissing);
             }
@@ -209,15 +212,15 @@ impl<CustomClaims> JWTClaims<CustomClaims> {
                 bail!(JWTError::RequiredNonceMissing);
             }
         }
-        if let Some(required_audience) = &options.required_audience {
+        if let Some(required_audiences) = &options.required_audiences {
             if let Some(audiences) = &self.audiences {
                 match audiences {
                     Audiences::AsString(audience) => ensure!(
-                        audience == required_audience,
+                        required_audiences.contains(audience),
                         JWTError::RequiredAudienceMismatch
                     ),
                     Audiences::AsSet(audiences) => ensure!(
-                        audiences.contains(required_audience),
+                        audiences.intersection(required_audiences).next().is_some(),
                         JWTError::RequiredAudienceMismatch
                     ),
                 };

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,5 @@
 use coarsetime::{Duration, UnixTimeStamp};
+use std::collections::HashSet;
 
 /// Additional features to enable during verification
 #[derive(Clone, Debug, Default)]
@@ -13,7 +14,7 @@ pub struct VerificationOptions {
     pub accept_future: bool,
 
     /// Require a specific issuer to be present
-    pub required_issuer: Option<String>,
+    pub required_issuers: Option<HashSet<String>>,
 
     /// Require a specific subject to be present
     pub required_subject: Option<String>,
@@ -28,7 +29,7 @@ pub struct VerificationOptions {
     pub required_nonce: Option<String>,
 
     /// Require a specific audience to be present
-    pub required_audience: Option<String>,
+    pub required_audiences: Option<HashSet<String>>,
 
     /// Time tolerance for validating expiration dates
     pub time_tolerance: Option<Duration>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -14,7 +14,7 @@ pub struct VerificationOptions {
     pub accept_future: bool,
 
     /// Require a specific issuer to be present
-    pub required_issuers: Option<HashSet<String>>,
+    pub allowed_issuers: Option<HashSet<String>>,
 
     /// Require a specific subject to be present
     pub required_subject: Option<String>,
@@ -29,7 +29,7 @@ pub struct VerificationOptions {
     pub required_nonce: Option<String>,
 
     /// Require a specific audience to be present
-    pub required_audiences: Option<HashSet<String>>,
+    pub allowed_audiences: Option<HashSet<String>>,
 
     /// Time tolerance for validating expiration dates
     pub time_tolerance: Option<Duration>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! // reject tokens if they were issued more than 1 hour ago
 //! options.max_validity = Some(Duration::from_hours(1));
 //! // reject tokens if they don't come from a specific issuer
-//! options.required_issuer = Some("example app".to_string());
+//! options.required_issuers = Some(["example app".to_string()].iter().cloned().collect());
 //! // see the documentation for the full list of available options
 //!
 //! let claims = key.verify_token::<NoCustomClaims>(&token, Some(options))?;
@@ -337,7 +337,7 @@ a3t0cyDKinOY7JGIwh8DWAa4pfEzgg56yLcilYSSohXeaQV0nR8+rm9J8GUYXjPK
         let claims = Claims::create(Duration::from_secs(86400)).with_issuer("test issuer");
         let token = key.authenticate(claims).unwrap();
         let options = VerificationOptions {
-            required_issuer: Some("test issuer".to_string()),
+            required_issuers: Some(["test issuer".to_string()].iter().cloned().collect()),
             ..Default::default()
         };
         let _claims = key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! // reject tokens if they were issued more than 1 hour ago
 //! options.max_validity = Some(Duration::from_hours(1));
 //! // reject tokens if they don't come from a specific issuer
-//! options.required_issuers = Some(["example app".to_string()].iter().cloned().collect());
+//! options.allowed_issuers = Some(["example app".to_string()].iter().cloned().collect());
 //! // see the documentation for the full list of available options
 //!
 //! let claims = key.verify_token::<NoCustomClaims>(&token, Some(options))?;
@@ -337,7 +337,7 @@ a3t0cyDKinOY7JGIwh8DWAa4pfEzgg56yLcilYSSohXeaQV0nR8+rm9J8GUYXjPK
         let claims = Claims::create(Duration::from_secs(86400)).with_issuer("test issuer");
         let token = key.authenticate(claims).unwrap();
         let options = VerificationOptions {
-            required_issuers: Some(["test issuer".to_string()].iter().cloned().collect()),
+            allowed_issuers: Some(["test issuer".to_string()].iter().cloned().collect()),
             ..Default::default()
         };
         let _claims = key

--- a/src/token.rs
+++ b/src/token.rs
@@ -173,8 +173,8 @@ fn should_verify_token() {
 
     let options = VerificationOptions {
         required_nonce: Some(nonce),
-        required_issuers: Some([issuer.to_string()].iter().cloned().collect()),
-        required_audiences: Some([audience.to_string()].iter().cloned().collect()),
+        allowed_issuers: Some([issuer.to_string()].iter().cloned().collect()),
+        allowed_audiences: Some([audience.to_string()].iter().cloned().collect()),
         ..Default::default()
     };
     key.verify_token::<NoCustomClaims>(&token, Some(options))
@@ -196,7 +196,7 @@ fn multiple_audiences() {
     let token = key.authenticate(claims).unwrap();
 
     let options = VerificationOptions {
-        required_audiences: Some(["audience 1".to_string()].iter().cloned().collect()),
+        allowed_audiences: Some(["audience 1".to_string()].iter().cloned().collect()),
         ..Default::default()
     };
     key.verify_token::<NoCustomClaims>(&token, Some(options))

--- a/src/token.rs
+++ b/src/token.rs
@@ -173,8 +173,8 @@ fn should_verify_token() {
 
     let options = VerificationOptions {
         required_nonce: Some(nonce),
-        required_issuer: Some(issuer.to_string()),
-        required_audience: Some(audience.to_string()),
+        required_issuers: Some([issuer.to_string()].iter().cloned().collect()),
+        required_audiences: Some([audience.to_string()].iter().cloned().collect()),
         ..Default::default()
     };
     key.verify_token::<NoCustomClaims>(&token, Some(options))
@@ -196,7 +196,7 @@ fn multiple_audiences() {
     let token = key.authenticate(claims).unwrap();
 
     let options = VerificationOptions {
-        required_audience: Some("audience 1".to_string()),
+        required_audiences: Some(["audience 1".to_string()].iter().cloned().collect()),
         ..Default::default()
     };
     key.verify_token::<NoCustomClaims>(&token, Some(options))


### PR DESCRIPTION
Hello,

It's common to validate `aud` against multiple values. Also some providers like [Google](https://developers.google.com/identity/sign-in/web/backend-auth) want users to validate `iss` against multiple values too.