### PR TITLE
Fix parsing UnixTimeStamp from floating point numbers

### DIFF
--- a/src/claims.rs
+++ b/src/claims.rs
@@ -352,4 +352,10 @@ mod tests {
         assert_eq!(claims.nonce, Some("nonce".to_owned()));
         assert_eq!(claims.subject, Some("subject".to_owned()));
     }
+
+    #[test]
+    fn parse_floating_point_unix_time() {
+        let claims: JWTClaims<()> = serde_json::from_str(r#"{"exp":1617757825.8}"#).unwrap();
+        assert_eq!(claims.expires_at, Some(UnixTimeStamp::from_secs(1617757825)));
+    }
 }

--- a/src/serde_additions.rs
+++ b/src/serde_additions.rs
@@ -26,6 +26,13 @@ pub mod unix_timestamp {
             Ok(UnixTimeStamp::from_secs(value))
         }
 
+        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            Ok(UnixTimeStamp::from_secs(value as _))
+        }
+
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("Unix timestamp")
         }


### PR DESCRIPTION
Fixes #21 