### PR TITLE
make media type assertion case-insensitive

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -135,7 +135,7 @@ impl Token {
             &Base64UrlSafeNoPadding::decode_to_vec(jwt_header_b64, None)?,
         )?;
         if let Some(signature_type) = &jwt_header.signature_type {
-            ensure!(signature_type == "JWT", JWTError::NotJWT);
+            ensure!(signature_type.to_uppercase() == "JWT", JWTError::NotJWT);
         }
         ensure!(
             jwt_header.algorithm == jwt_alg_name,


### PR DESCRIPTION
I stumbled over this assertion that makes a JWT invalid that contains `"type":"jwt"` in its header. However, according to the JWT spec using uppercase is just "recommended" but technically not required since media types are case-insensitive (see also [here](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1)):

> While media type names are not case sensitive, it is RECOMMENDED that "JWT" always be spelled using uppercase characters for compatibility with legacy implementations.

This PR makes the assertion in the code case-insensitive.

PS: I did not find any contributing guidelines, so let me know if I need to add anything else 🙂 