### PR TITLE
Configurable max header length

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -47,6 +47,9 @@ pub struct VerificationOptions {
 
     /// Maximum token length to accept
     pub max_token_length: Option<usize>,
+
+    /// Maximum header length to accept
+    pub max_header_length: Option<usize>,
 }
 
 impl Default for VerificationOptions {
@@ -63,6 +66,7 @@ impl Default for VerificationOptions {
             time_tolerance: Some(Duration::from_secs(DEFAULT_TIME_TOLERANCE_SECS)),
             max_validity: None,
             max_token_length: Some(DEFAULT_MAX_TOKEN_LENGTH),
+            max_header_length: None,
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -137,7 +137,7 @@ impl Token {
         let mut parts = token.split('.');
         let jwt_header_b64 = parts.next().ok_or(JWTError::CompactEncodingError)?;
         ensure!(
-            jwt_header_b64.len() <= MAX_HEADER_LENGTH,
+            jwt_header_b64.len() <= options.max_header_length.unwrap_or(MAX_HEADER_LENGTH),
             JWTError::HeaderTooLarge
         );
         let claims_b64 = parts.next().ok_or(JWTError::CompactEncodingError)?;


### PR DESCRIPTION
I found another case where the maximum header size is too small: Azure uses JWTs in its Key Vault API to return released keys. The JWT header contains a certificate chain, making it rather large (8465 bytes in the JWT I got).

#5 already increased the header size in the past, but perhaps a more future-proof solution is to allow users to overwrite the maximum size. This PR adds an option to set a custom max length for a header. Using `None` will default to `MAX_HEADER_LENGTH`.