### PR TITLE
Bugfix/ps256 salt len

### DIFF
--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -748,7 +748,7 @@ impl RSAKeyPairLike for PS256KeyPair {
     }
 
     fn padding_scheme(&self) -> rsa::PaddingScheme {
-        rsa::PaddingScheme::new_pss_with_salt::<SHA256>(256)
+        rsa::PaddingScheme::new_pss_with_salt::<SHA256>(32)
     }
 }
 

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -748,7 +748,7 @@ impl RSAKeyPairLike for PS256KeyPair {
     }
 
     fn padding_scheme(&self) -> rsa::PaddingScheme {
-        rsa::PaddingScheme::new_pss::<SHA256>()
+        rsa::PaddingScheme::new_pss_with_salt::<SHA256>(256)
     }
 }
 


### PR DESCRIPTION
There is some bug in signing JWT by PS256.
jwt.io says that verification failed for JWT generated by this crate.

It happens because:

    The size of the salt value is the same size as
    the hash function output. All other algorithm parameters use the
    defaults specified in Appendix A.2.3 of RFC 3447.


That is a fix