### PR TITLE
Upgrade rsa to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jwt-simple"
-version = "0.11.8"
+version = "0.11.9"
 description = "Easy to use, secure, non opinionated JWT (JSON Web Tokens) implementation for Rust."
 authors = ["Frank Denis <github@pureftpd.org>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ k256 = { version = "0.13.1", features = ["ecdsa", "std", "pkcs8", "pem"] }
 p256 = { version = "0.13.2", features = ["ecdsa", "std", "pkcs8", "pem"] }
 p384 = { version = "0.13.0", features = ["ecdsa", "std", "pkcs8", "pem"] }
 rand = "0.8.5"
-rsa = "0.7.2"
+rsa = "0.9.3"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"
 spki = "0.6.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-pub use anyhow::{anyhow, bail, ensure, Error};
+pub use anyhow::{bail, ensure, Error};
 
 #[derive(Debug, thiserror::Error)]
 pub enum JWTError {


### PR DESCRIPTION
I have [another old branch](https://github.com/grafbase/rust-jwt-simple/tree/rsa-0.8) that upgrades to 0.8, but I guess we can ignore it.