### PR TITLE
Feature: pure rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 *~
 .vscode/
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ spki = { version = "0.6.0", optional = true }
 [target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dependencies]
 rsa = "0.8.2"
 spki = "0.6.0"
+getrandom = { version = "0.2.11", features = ["js"] }
 
 [dev-dependencies]
 benchmark-simple = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ thiserror = "1.0.50"
 zeroize = "1.7.0"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
-boring = "4.1.0"
+boring = { version = "4.1.0", optional = true }
+rsa = { version = "0.8.2", optional = true }
+spki = { version = "0.6.0", optional = true }
 
 [target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dependencies]
 rsa = "0.8.2"
@@ -41,7 +43,9 @@ spki = "0.6.0"
 benchmark-simple = "0.1.8"
 
 [features]
+default = ["dep:boring"]
 cwt = ["ciborium"]
+pure-rust = ["dep:rsa", "dep:spki"]
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
This should solve #102 

Add `pure-rust` as an optional feature flag. This makes the `boring` dependency opt-out if you have conflicts you cannot easily resolve.

Usage:

```
jwt-simple = { path = "../rust-jwt-simple", default-features = false, features = ["pure-rust"] }
```

This should be able to compile to wasm automatically too, though I do not have a setup to test this right now.