### PR TITLE
set default time-tolerance to 0

### DIFF
--- a/src/claims.rs
+++ b/src/claims.rs
@@ -10,7 +10,7 @@ use crate::common::VerificationOptions;
 use crate::error::*;
 use crate::serde_additions;
 
-pub const DEFAULT_TIME_TOLERANCE_SECS: u64 = 900;
+pub const DEFAULT_TIME_TOLERANCE_SECS: u64 = 0;
 
 /// Type representing the fact that no application-defined claims is necessary.
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize)]
@@ -177,10 +177,7 @@ impl<CustomClaims> JWTClaims<CustomClaims> {
             .artificial_time
             .unwrap_or_else(Clock::now_since_epoch);
         
-        let time_tolerance = match options.time_tolerance {
-            Some(tolerance) => tolerance,
-            None => Duration::from_secs(0)
-        };
+        let time_tolerance = options.time_tolerance.unwrap_or_default();
 
         if let Some(reject_before) = options.reject_before {
             ensure!(now >= reject_before, JWTError::OldTokenReused);

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -176,7 +176,11 @@ impl<CustomClaims> JWTClaims<CustomClaims> {
         let now = options
             .artificial_time
             .unwrap_or_else(Clock::now_since_epoch);
-        let time_tolerance = options.time_tolerance.unwrap_or_default();
+        
+        let time_tolerance = match options.time_tolerance {
+            Some(tolerance) => tolerance,
+            None => Duration::from_secs(0)
+        };
 
         if let Some(reject_before) = options.reject_before {
             ensure!(now >= reject_before, JWTError::OldTokenReused);


### PR DESCRIPTION
when not setting a time tolerance when creating a token, the token will not expire as the default is a large number. 
this sets it so that the default is 0, so the token will expire in the time that is given when the token is created.

default should be 0 or the docs should say that the default is 15min