### PR TITLE
fix(claims): deser exact integer timestamp values from claims

### DIFF
--- a/src/serde_additions.rs
+++ b/src/serde_additions.rs
@@ -16,21 +16,21 @@ pub mod unix_timestamp {
         where
             E: DeError,
         {
-            Ok(UnixTimeStamp::from_secs(value as _))
+            Ok(UnixTimeStamp::from_ticks(value as _))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
         where
             E: DeError,
         {
-            Ok(UnixTimeStamp::from_secs(value))
+            Ok(UnixTimeStamp::from_ticks(value))
         }
 
         fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
         where
             E: DeError,
         {
-            Ok(UnixTimeStamp::from_secs(value as _))
+            Ok(UnixTimeStamp::from_ticks(value as _))
         }
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
When deserializing JWT claims from JSON inputs, the hardcoded values for issued_at, expires_at, invalid_before, etc. are bit-shifted to values which do not match the input. This PR uses UnixTimestamp methods which passthrough the values from the deserializer's input so that the resultant claims match the expected values from the input.