### PR TITLE
Optionally support openssl instead of boringssl backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: Rust
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+  - push
+  - pull_request
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,8 +17,10 @@ jobs:
         run: cargo build
       - name: build with cwt
         run: cargo build --features="cwt"
-      - name: pure rust implementations
+      - name: pure rust implementation
         run: cargo build --no-default-features --features="pure-rust"
+      - name: openssl implementation
+        run: cargo build --no-default-features --features="openssl"
       - name: wasm32-freestanding build
         run: |
           rustup target add wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2.0.0"
 zeroize = "1.8.1"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+openssl = { version = "0.10.68", optional = true }
 boring = { version = "4.11.0", optional = true }
 superboring = { version = "0.1.3", optional = true }
 
@@ -44,6 +45,7 @@ benchmark-simple = "0.1.10"
 [features]
 default = ["optimal"]
 cwt = ["ciborium"]
+openssl = ["dep:openssl"]
 optimal = ["boring"]
 # Note: to emulate boringssl, "default-features = false" is required in addition to "pure-rust".
 pure-rust = ["superboring"]

--- a/README.md
+++ b/README.md
@@ -295,11 +295,14 @@ As a mitigation, we highly recommend rejecting tokens that would be too large in
 
 ## Working around compilation issues with the `boring` crate
 
-As a temporary workaround for portability issues with one of the dependencies (the `boring` crate), this library can be compiled to use only Rust implementations.
+The default dependency `boring-sys` [currently conflicts with `openssl-sys`](https://github.com/cloudflare/boring/issues/197).
 
-In order to do so, import the crate with `default-features=false, features=["pure-rust"]` in your Cargo configuration.
+As a temporary workaround for portability, import the crate with one of these in your `Cargo.toml`:
 
-Do not do it unconditionally. This is only required for very specific setups and targets, and only until issues with the `boring` crate have been solved. The way to configure this in Cargo may also change in future versions.
+* `default-features = false, features = ["openssl"]` to use OpenSSL instead of BoringSSL
+* `default-features = false, features = ["pure-rust"]` to use only Rust implementations
+
+Do not do it unconditionally. This is only required for very specific setups and targets, and only until issues with the `boring` crate have been solved. There is a performance cost, and the way to configure this in Cargo may also change in future versions.
 
 Static builds targeting the `musl` library don't require that workaround. Just use [`cargo-zigbuild`](https://github.com/rust-cross/cargo-zigbuild) to build your project.
 

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -1,15 +1,23 @@
+#[cfg(all(
+    feature = "optimal",
+    not(target_arch = "wasm32"),
+    not(target_arch = "wasm64")
+))]
+use boring as ssl;
+#[cfg(feature = "openssl")]
+use openssl as ssl;
 #[cfg(any(feature = "pure-rust", target_arch = "wasm32", target_arch = "wasm64"))]
-use superboring as boring;
+use superboring as ssl;
 
-use boring::bn::BigNum;
-use boring::hash::MessageDigest;
-use boring::pkey::{PKey, Private, Public};
-use boring::rsa::{Padding, Rsa};
-use boring::sign::{Signer, Verifier};
 use ct_codecs::{Base64UrlSafeNoPadding, Encoder};
 use hmac_sha1_compact::Hash as SHA1;
 use hmac_sha256::Hash as SHA256;
 use serde::{de::DeserializeOwned, Serialize};
+use ssl::bn::BigNum;
+use ssl::hash::MessageDigest;
+use ssl::pkey::{PKey, Private, Public};
+use ssl::rsa::{Padding, Rsa};
+use ssl::sign::{Signer, Verifier};
 
 use crate::claims::*;
 use crate::common::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,11 +302,19 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(all(feature = "openssl", feature = "optimal"))]
+compile_error!("jwt-simple: the `openssl` feature is only available when the `optimal` feature is disabled - consider disabling default Cargo features");
 #[cfg(all(feature = "pure-rust", feature = "optimal"))]
-compile_error!("jwt-simple: the `optimal` feature is only available when the `pure-rust` feature is disabled - Consider disabling default Cargo features.");
+compile_error!("jwt-simple: the `pure-rust` feature is only available when the `optimal` feature is disabled - consider disabling default Cargo features");
+#[cfg(all(feature = "openssl", feature = "pure-rust"))]
+compile_error!("jwt-simple: the `openssl` feature and `pure-rust` feature cannot both be enabled");
 
-#[cfg(all(not(feature = "pure-rust"), not(feature = "optimal")))]
-compile_error!("jwt-simple: the `optimal` feature is required when the `pure-rust` feature is disabled - Consider enabling default Cargo features.");
+#[cfg(all(
+    not(feature = "optimal"),
+    not(feature = "openssl"),
+    not(feature = "pure-rust")
+))]
+compile_error!("jwt-simple: all features `optimal`, `openssl`, and `pure-rust` are disabled, but one is needed - consider enabling default Cargo features");
 
 pub mod algorithms;
 pub mod claims;


### PR DESCRIPTION
As another workaround for the linker conflict with openssl that doesn't sacrifice as much performance.

```
$ cargo bench
[...]
rsa-2048 - sign: 1.81 K/s
rsa-2048 - verify: 72.28 K/s

$ cargo bench --no-default-features --features pure-rust
[...]
rsa-2048 - sign: 714.39 /s
rsa-2048 - verify: 6.75 K/s

$ cargo bench --no-default-features --features openssl
[...]
rsa-2048 - sign: 1.29 K/s
rsa-2048 - verify: 41.05 K/s
```