### PR TITLE
fix: prevent HMACKey secret from leaking via Debug

### DIFF
--- a/src/algorithms/hmac.rs
+++ b/src/algorithms/hmac.rs
@@ -13,10 +13,16 @@ use crate::jwt_header::*;
 use crate::token::*;
 
 #[doc(hidden)]
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HMACKey {
     raw_key: Vec<u8>,
     metadata: Option<KeyMetadata>,
+}
+
+impl std::fmt::Debug for HMACKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HMACKey([redacted])")
+    }
 }
 
 impl Drop for HMACKey {


### PR DESCRIPTION
`HMACKey` previously derived `Debug`, which would print the raw key bytes.

This PR implements `Debug` manually without exposing key data.