### PR TITLE
Unpin and upgrade rand to 0.8.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hmac-sha512 = { version = "1.1.12", features = ["traits010", "sha384"] }
 k256 = { version = "0.13.4", features = ["ecdsa", "std", "pkcs8", "pem"] }
 p256 = { version = "0.13.2", features = ["ecdsa", "std", "pkcs8", "pem", "ecdh"] }
 p384 = { version = "0.13.1", features = ["ecdsa", "std", "pkcs8", "pem"] }
-rand = "=0.8.5"
+rand = "0.8.6"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"


### PR DESCRIPTION
This addresses [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097.html) by allowing `rand` to be upgraded to a patch version incorporating a fix that was back-ported to 0.8 in https://github.com/rust-random/rand/pull/1772

`rand` was pinned to `=0.8.5` in https://github.com/jedisct1/rust-jwt-simple/commit/a4c10d703f793b640883156fd3ecc9a79be176ae a year ago. The 0.8.6 patch was only released last week so I'm guessing the intent of the exact version pinning was to suppress Dependabot trying to upgrade major versions, not to prevent patch upgrades.